### PR TITLE
Prefer left-alignment when both are equal

### DIFF
--- a/src/react-float-affixed.jsx
+++ b/src/react-float-affixed.jsx
@@ -28,7 +28,7 @@ function align(aedge,pedge) {
 function edgeAlignMaxSpace(amin, amax, pmin, pmax, space) {
     let rspace = space - amax;
     let lspace = amin;
-    return (rspace <= lspace) ? amax - pmax : amin - pmin;
+    return (rspace < lspace) ? amax - pmax : amin - pmin;
 }
 
 // given a delta, popup bounds, and available space


### PR DESCRIPTION
When full-width, chooses right alignment. This fixes this to choose left alignment when space is equal on both sides.